### PR TITLE
replace -std=c++17 with -std=c++11

### DIFF
--- a/netconsd/modules/Makefile
+++ b/netconsd/modules/Makefile
@@ -4,7 +4,7 @@ CCC = g++
 CFLAGS = -O2 -D_GNU_SOURCE -fPIC -fno-strict-aliasing -Wall -Wextra \
 	-Wno-unused-function -Wno-unused-parameter \
 	-Wno-missing-field-initializers
-CCFLAGS = -std=c++17 $(CFLAGS)
+CCFLAGS = -std=c++11 $(CFLAGS)
 INCLUDES = -I../../ncrx -I ../include
 
 mods = printer.so logger.so


### PR DESCRIPTION
We don't need the c++17 features, and it confuses coverity.