### PR TITLE
Basic automatic anomaly detection

### DIFF
--- a/benchpress/benchpress/cli/commands/run.py
+++ b/benchpress/benchpress/cli/commands/run.py
@@ -10,6 +10,7 @@ import logging
 from datetime import datetime, timezone
 
 from .command import BenchpressCommand
+from benchpress.lib.analysis import analyze
 from benchpress.lib.history import History
 from benchpress.lib.reporter_factory import ReporterFactory
 
@@ -51,7 +52,9 @@ class RunCommand(BenchpressCommand):
 
             metrics = job.run()
 
-            reporter.report(job, metrics)
+            anomalies = analyze(metrics, job, history)
+
+            reporter.report(job, metrics, anomalies)
 
             history.save_job_result(job, metrics, now)
 

--- a/benchpress/benchpress/lib/analysis.py
+++ b/benchpress/benchpress/lib/analysis.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+from collections import defaultdict
+
+
+def analyze(current, job, history):
+    """Given a Metrics object and the job, return a list of
+    metrics that are outside the acceptable range. Acceptable range is based on
+    a percentage tolerance defined in the job configuration centered around the
+    the average of historical results.
+
+    Args:
+        current (Metrics): current job results
+        job (Job): job that was run
+        history (History): history interface
+    Returns:
+        list (metric name, value, min, max): metrics outside acceptable range
+    """
+    historical = history.load_historical_results(job)
+    results_by_metrics = defaultdict(list)
+    for entry in historical:
+        metrics = entry.metrics.performance_metrics()
+        for key, value in metrics.items():
+            results_by_metrics[key].append(value)
+    averages = {metric: sum(results) / len(results)
+                for metric, results in results_by_metrics.items()}
+    outside_range = []
+    for metric, tolerance in job.tolerances.items():
+        average = averages[metric]
+        value = current[metric]
+        min = average * (1 - tolerance)
+        max = average * (1 + tolerance)
+        if value < min or value > max:
+            outside_range.append((metric, value, min, max))
+    return outside_range

--- a/benchpress/benchpress/lib/job.py
+++ b/benchpress/benchpress/lib/job.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-from collections import defaultdict
 import errno
 import logging
 import subprocess
@@ -60,6 +59,8 @@ class Job(object):
     Attributes:
         name (str): short name to identify job
         description (str): longer description to state intent of job
+        tolerances (dict str: number): percentage tolerance around the mean of
+                                       historical results
         config (dict): raw configuration dictionary
     """
 
@@ -92,6 +93,9 @@ class Job(object):
         self.hook_opts = hook_conf.get('options', {})
         self.hook = HookFactory.create(hook_conf['hook'])
         self.metrics_config = MetricsConfig(config['metrics'])
+
+        self.tolerances = config.get('tolerances', {})
+        self.tolerances = Metrics.flatten(self.tolerances)
 
         self.args = self.arg_list(config['args'])
 

--- a/benchpress/benchpress/lib/metrics.py
+++ b/benchpress/benchpress/lib/metrics.py
@@ -20,12 +20,13 @@ class Metrics(object):
         self.metrics_dict = self.flatten(metrics_dict)
         self.names = sorted(list(self.metrics_dict.keys()))
 
-    def flatten(self, metrics, prefix=''):
+    @staticmethod
+    def flatten(metrics, prefix=''):
         """Flattens given dict using dot separated keys."""
         flattened = {}
         if isinstance(metrics, dict):
             for key, metric in metrics.items():
-                flattened.update(self.flatten(metric, prefix + key + '.'))
+                flattened.update(Metrics.flatten(metric, prefix + key + '.'))
         else:
             flattened = {str(prefix[:-1]): metrics}
 

--- a/benchpress/benchpress/lib/reporter.py
+++ b/benchpress/benchpress/lib/reporter.py
@@ -16,12 +16,13 @@ class Reporter(object, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def report(self, job, metrics):
+    def report(self, job, metrics, anomalies):
         """Save job metrics somewhere in existing monitoring infrastructure.
 
         Args:
             job (Job): job that was run
             metrics (Metrics): metrics that were exported by job
+            anomalies (list of (name, value, min, max)): anomalies
         """
         pass
 
@@ -34,7 +35,7 @@ class Reporter(object, metaclass=ABCMeta):
 
 class StdoutReporter(Reporter):
     """Default reporter implementation, logs a JSON object to stdout."""
-    def report(self, job, metrics):
+    def report(self, job, metrics, anomalies):
         """Log JSON report to stdout.
         Attempt to detect whether a real person is running the program then
         pretty print the JSON, otherwise print it without linebreaks and
@@ -42,8 +43,24 @@ class StdoutReporter(Reporter):
         """
         # use isatty as a proxy for if a real human is running this
         if sys.stdout.isatty():
-            json.dump(metrics.metrics(), sys.stdout, sort_keys=True, indent=2)
+            # if on the console, write in a more human-readable form
+            print('Metrics')
+            print('-------')
+            for key in sorted(metrics.names):
+                print('{}={}'.format(key, metrics[key]))
+            if anomalies:
+                print('Possible anomalies')
+                print('------------------')
+                anomaly_names = [a[0] for a in anomalies]
+                anomalies = {a[0]: a for a in anomalies}
+                for name in sorted(anomaly_names):
+                    _, val, min, max = anomalies[name]
+                    print('{}={} not in range ({}, {})'.format(name, val, min, max))
         else:
+            obj = {
+                'metrics': metrics.metrics(),
+                'anomalies': anomalies
+            }
             json.dump(metrics.metrics(), sys.stdout)
         sys.stdout.write('\n')
 

--- a/benchpress/tests/test_analysis.py
+++ b/benchpress/tests/test_analysis.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import unittest
+from unittest.mock import MagicMock
+
+from benchpress.lib.analysis import analyze
+from benchpress.lib.metrics import Metrics
+
+
+def metrics(results):
+    """Create a mock HistoryEntry from the results"""
+    mock = MagicMock()
+    mock.metrics.performance_metrics.return_value = results
+    return mock
+
+
+class TestAnalysis(unittest.TestCase):
+    def setUp(self):
+        self.job = MagicMock()
+        self.history = MagicMock()
+        self.history.load_historical_results.return_value = [
+            metrics({'a': 1, 'b': 2, 'c': 3}),
+            metrics({'a': 2, 'b': 1, 'c': 2}),
+            metrics({'a': 1, 'b': 3, 'c': 4}),
+            metrics({'a': 2, 'b': 2, 'c': 3}),
+            metrics({'a': 1, 'b': 1, 'c': 1}),
+            metrics({'a': 2, 'b': 2, 'c': 5}),
+        ]
+
+    def test_no_thresholds(self):
+        """No thresholds -> no anomalies"""
+        self.job.tolerances = {}
+        current = {'a': 1, 'b': 2, 'c': 3}
+        anomalies = analyze(current, self.job, self.history)
+        self.assertEqual(0, len(anomalies))
+
+    def test_no_anomalies(self):
+        """No anomalous metric"""
+        self.job.tolerances = {'a': 1.0, 'b': 1.0, 'c': 1.0}
+        current = {'a': 2, 'b': 2, 'c': 3}
+        anomalies = analyze(current, self.job, self.history)
+        self.assertEqual(0, len(anomalies))
+
+    def test_one_anomaly(self):
+        """One anomalous metric"""
+        self.job.tolerances = {'a': 1.0, 'b': 1.0, 'c': 1.0}
+        current = {'a': 4, 'b': 2, 'c': 3}
+        anomalies = analyze(current, self.job, self.history)
+        expected = [('a', 4, 0.0, 3.0)]
+        self.assertCountEqual(expected, anomalies)
+
+    def test_nested_names(self):
+        """Nested tolerance dicts work"""
+        self.job.tolerances = {'a': {'b': 1}}
+        # Job constructor uses Metrics#flatten for tolerances as well
+        self.job.tolerances = Metrics.flatten(self.job.tolerances)
+        self.history.load_historical_results.return_value = [
+            metrics({'a.b': 1})
+        ]
+        current = {'a.b': 4}
+        anomalies = analyze(current, self.job, self.history)
+        expected = [('a.b', 4, 0.0, 2.0)]
+        self.assertCountEqual(expected, anomalies)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add basic anomaly detection features. Opt-in to give metrics a
configurable tolerance around the mean of historical results.
Change output format of stdout reporter when running in tty mode to
print metrics in 'name=value' format on individual lines, and print
possible anomalies following all of the results.