### PR TITLE
Schbench configuration and CPU limiter

### DIFF
--- a/benchpress/benchpress/plugins/hooks/__init__.py
+++ b/benchpress/benchpress/plugins/hooks/__init__.py
@@ -6,12 +6,14 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+from .cpu_limit import CpuLimit
 from .noop import NoopHook
 from .file import FileHook
 from .shell import ShellHook
 
 
 def register_hooks(factory):
+    factory.register('cpu-limit', CpuLimit)
     factory.register('noop', NoopHook)
     factory.register('file', FileHook)
     factory.register('shell', ShellHook)

--- a/benchpress/benchpress/plugins/hooks/cpu_limit.py
+++ b/benchpress/benchpress/plugins/hooks/cpu_limit.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import logging
+
+from benchpress.lib.hook import Hook
+
+logger = logging.getLogger(__name__)
+
+
+class CpuLimit(Hook):
+    """CpuLimit hook allows you to limit the benchmark to a set of CPUs using
+    `taskset`. The only option is a hex string bitmask that is the CPU mask
+    passed to `taskset`, for each bit, if there is a 1 the CPU is enabled for
+    the benchmark process, otherwise it's disabled.
+    """
+
+    def before_job(self, opts, job):
+        mask = str(opts)
+        # try to parse the mask as a hex string as a basic sanity check
+        try:
+            int(mask, 16)
+        except ValueError:
+            raise ValueError('{} is not a valid CPU mask'.format(mask))
+
+        # modify the job config to run taskset with the given mask instead of
+        # directly running the benchmark binary
+        binary = job.config['path']
+        job.args = [mask, binary] + job.args
+        job.binary = 'taskset'
+
+    def after_job(self, opts, job):
+        pass

--- a/benchpress/jobs/jobs.yml
+++ b/benchpress/jobs/jobs.yml
@@ -1,8 +1,3 @@
-- name: fio tests
-  description: fio tests
-  tests:
-  - fio null
-  - fio aio
 - benchmark: schbench
   name: schbench default 
   description: defaults for schbench
@@ -14,6 +9,25 @@
     cputime: 10000
     pipe: 0
     rps: 0
+- benchmark: schbench
+  name: schbench-load-test
+  description: p95 latency when cpu under high load
+  args:
+    message-threads: 2
+    threads: 16
+    runtime: 30
+    sleeptime: 30000
+    cputime: 30000
+    pipe: 0
+    rps: 0
+  hook:
+    hook: cpu-limit
+    options: 0xfffffffff
+- name: fio tests
+  description: fio tests
+  tests:
+  - fio null
+  - fio aio
 - benchmark: fio
   name: fio null
   description: read /dev/null


### PR DESCRIPTION
Add a schbench configuration that is pretty good at differentiating
between before and after Chris Mason's scheduler patch. This required
using taskset to limit the CPU affinity of the benchmark process, so
also added a 'cpu-limit' hook to make this easy.