### PR TITLE
benchpress: Fix broken tests

### DIFF
--- a/benchpress/benchpress/plugins/hooks/__init__.py
+++ b/benchpress/benchpress/plugins/hooks/__init__.py
@@ -7,13 +7,11 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 from .cpu_limit import CpuLimit
-from .noop import NoopHook
 from .file import FileHook
 from .shell import ShellHook
 
 
 def register_hooks(factory):
     factory.register('cpu-limit', CpuLimit)
-    factory.register('noop', NoopHook)
     factory.register('file', FileHook)
     factory.register('shell', ShellHook)

--- a/benchpress/tests/test_history.py
+++ b/benchpress/tests/test_history.py
@@ -36,10 +36,7 @@ class TestHistory(fake_filesystem_unittest.TestCase):
             'args': ['somearg'],
             'benchmark': 'bench',
             'description': 'cool description',
-            'hook': {
-                'hook': 'noop',
-                'options': []
-            },
+            'hooks': [],
             'metrics': ['mysupercoolmetric'],
             'name': 'job name',
         }, {
@@ -54,10 +51,7 @@ class TestHistory(fake_filesystem_unittest.TestCase):
                                "args": ["somearg"],
                                "benchmark": "bench",
                                "description": "cool description",
-                               "hook": {
-                                 "hook": "noop",
-                                 "options": []
-                               },
+                               "hooks": [],
                                "metrics": ["mysupercoolmetric"],
                                "name": "job name",
                                "path": "true",
@@ -86,10 +80,7 @@ class TestHistory(fake_filesystem_unittest.TestCase):
             'args': ['somearg'],
             'benchmark': 'bench',
             'description': 'cool description',
-            'hook': {
-                'hook': 'noop',
-                'options': []
-            },
+            'hooks': [],
             'metrics': ['mysupercoolmetric'],
             'name': 'job name',
         }, {
@@ -133,10 +124,7 @@ class TestHistory(fake_filesystem_unittest.TestCase):
                                "args": ["somearg"],
                                "benchmark": "bench",
                                "description": "cool description",
-                               "hook": {
-                                 "hook": "noop",
-                                 "options": []
-                               },
+                               "hooks": [],
                                "metrics": ["mysupercoolmetric"],
                                "name": "job name",
                                "path": "true",

--- a/benchpress/tests/test_shell_hook.py
+++ b/benchpress/tests/test_shell_hook.py
@@ -7,6 +7,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 import os
+from pyfakefs import fake_filesystem_unittest
 import subprocess
 import unittest
 from unittest.mock import patch
@@ -14,11 +15,14 @@ from unittest.mock import patch
 from benchpress.plugins.hooks.shell import ShellHook
 
 
-class TestShellHook(unittest.TestCase):
+class TestShellHook(fake_filesystem_unittest.TestCase):
 
     def setUp(self):
+        self.setUpPyfakefs()
         self.original_dir = os.getcwd()
         self.hook = ShellHook()
+
+        self.fs.CreateDirectory('/tmp')
 
     def tearDown(self):
         os.chdir(self.original_dir)


### PR DESCRIPTION
History tests semi-broken due to new hook file format. The new test
makes sure that that the saved file is in a format consistent with the
latest format generated by the code.

Shell hook tests were flaky because they relied on `/tmp` existing and
`/tmp` being the absolute path - this tests fails on MacOS because
`/tmp` is actually a symlink to `/private/tmp`. Use pyfakefs in this
test case to ensure that the results are repeatable cross-platform.