### PR TITLE
[benchpress] parse before cleaning up

### DIFF
--- a/benchpress/tests/test_job.py
+++ b/benchpress/tests/test_job.py
@@ -62,7 +62,7 @@ class TestJob(unittest.TestCase):
         job = Job(self.job_config, self.mock_benchmark)
 
         metrics = job.run()
-        self.mock_parser.parse.assert_called_with([mock_data, ''], [''], 0)
+        self.mock_parser.parse.assert_called_with([mock_data], [], 0)
         self.assertDictEqual({'key': 'hello'}, metrics)
 
     def test_run_fail(self):


### PR DESCRIPTION
For some test suites (e.g., xfstests), we need to parse output files to
get all of the metrics. We can't do this if we clean up before we call
the parser.