### PR TITLE
netconsd listen on specific address

### DIFF
--- a/netconsd/include/common.h
+++ b/netconsd/include/common.h
@@ -75,9 +75,9 @@ struct netconsd_params {
 	int nr_workers;
 	int nr_listeners;
 	int mmsg_batch;
-	int udp_listen_port;
 	unsigned int gc_int_ms;
 	unsigned int gc_age_ms;
+	struct sockaddr_in6 listen_addr;
 };
 
 #endif /* __COMMON_H__ */

--- a/netconsd/include/listener.h
+++ b/netconsd/include/listener.h
@@ -28,9 +28,9 @@ struct ncrx_listener {
 	struct ncrx_prequeue *prequeues;
 	struct ncrx_worker *workers;
 	int nr_workers;
-	int port;
 	int batch;
 	uint64_t processed;
+	struct sockaddr_in6 *address;
 
 	/*
 	 * Flags

--- a/netconsd/include/log.h
+++ b/netconsd/include/log.h
@@ -6,7 +6,6 @@
  * file in the root directory of this source tree. An additional grant of patent
  * rights can be found in the PATENTS file in the same directory.
  */
-
 #ifndef __LOG_H__
 #define __LOG_H__
 

--- a/netconsd/threads.c
+++ b/netconsd/threads.c
@@ -185,8 +185,8 @@ static void create_listener_threads(struct tctl *ctl, struct netconsd_params *p)
 		cur->prequeues = prequeues;
 		cur->workers = ctl->workers;
 		cur->nr_workers = ctl->nr_workers;
-		cur->port = p->udp_listen_port;
 		cur->batch = p->mmsg_batch;
+		cur->address = &p->listen_addr;
 
 		r = pthread_create(&cur->id, NULL, udp_listener_thread, cur);
 		if (r)


### PR DESCRIPTION
Instead of accepting traffic from anywhere, this allows netconsd to only listen for traffic from a specific address.

to test this, I built and ran both netconsd and netconsblaster. when running netconsd with "-a ::1", it displays all the messages from netconsblaster in the other terminal. When running netconsd listening on other addresses, the traffic from netconsblaster is dropped.