### PR TITLE
[benchpress] Add generic JSON parser

### DIFF
--- a/benchpress/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/benchpress/plugins/parsers/__init__.py
@@ -7,6 +7,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 from .fio import FioParser
+from .generic import JSONParser
 from .ltp import LtpParser
 from .returncode import ReturncodeParser
 from .schbench import SchbenchParser
@@ -15,6 +16,7 @@ from .silo import SiloParser
 
 def register_parsers(factory):
     factory.register('fio', FioParser)
+    factory.register('json', JSONParser)
     factory.register('ltp', LtpParser)
     factory.register('returncode', ReturncodeParser)
     factory.register('schbench', SchbenchParser)

--- a/benchpress/benchpress/plugins/parsers/generic.py
+++ b/benchpress/benchpress/plugins/parsers/generic.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import json
+import logging
+
+from benchpress.lib.parser import Parser
+
+
+class JSONParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        """Converts JSON output from either stdout or stderr into a dict.
+
+        Assumes that either stdout or stderr contains only valid JSON, as
+        expected by the `json` module.
+
+        Args:
+            stdout (list[str]): Process's line-by-line stdout output.
+            stderr (list[str]): Process's line-by-line stderr output.
+            returncode (int): Process's exit status code.
+
+        Returns:
+            metrics (dict): Representation of either stdout or stderr.
+
+        Raises:
+            ValueError: When neither stdout nor stderr could be parsed as JSON.
+        """
+        err_msg = 'Failed to parse {1} as JSON: {0}'
+        for (output, kind) in [(stdout, 'stdout'), (stderr, 'stderr')]:
+            process_output = '\n'.join(output)
+            try:
+                return json.loads(process_output)
+            except ValueError as err:
+                logging.warning(err_msg.format(err, kind))
+
+        msg = "Couldn't not find or parse JSON from either stdout or stderr"
+        raise ValueError(msg)

--- a/benchpress/tests/__init__.py
+++ b/benchpress/tests/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import logging
+
+# Disables logging while running unit tests
+logging.disable(logging.CRITICAL)

--- a/benchpress/tests/test_json_parser.py
+++ b/benchpress/tests/test_json_parser.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import unittest
+
+from benchpress.plugins.parsers.generic import JSONParser
+
+
+class TestJSONParser(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = JSONParser()
+
+    def test_parse_expected_output(self):
+        output = [
+            '{',
+            '"Combined": {',
+            '"Siege requests": 4808,',
+            '"Siege wall sec": 2.42,',
+            '"Siege RPS": 81.01,'
+            '"Siege successful requests": 4609,',
+            '"Siege failed requests": 0,',
+            '"Nginx hits": 5008,',
+            '"Nginx avg bytes": 188779.63238818,',
+            '"Nginx avg time": 2.3533458466454,',
+            '"Nginx P50 time": 2.365,',
+            '"Nginx P90 time": 3.095,',
+            '"Nginx P95 time": 3.378,',
+            '"Nginx P99 time": 3.771,',
+            '"Nginx 200": 4609,',
+            '"Nginx 499": 200,',
+            '"Nginx 404": 199,',
+            '"canonical": 1',
+            '}',
+            '}',
+        ]
+        expected_dict = {
+            "Combined": {
+                "Siege requests": 4808,
+                "Siege wall sec": 2.42,
+                "Siege RPS": 81.01,
+                "Siege successful requests": 4609,
+                "Siege failed requests": 0,
+                "Nginx hits": 5008,
+                "Nginx avg bytes": 188779.63238818,
+                "Nginx avg time": 2.3533458466454,
+                "Nginx P50 time": 2.365,
+                "Nginx P90 time": 3.095,
+                "Nginx P95 time": 3.378,
+                "Nginx P99 time": 3.771,
+                "Nginx 200": 4609,
+                "Nginx 499": 200,
+                "Nginx 404": 199,
+                "canonical": 1
+            }
+        }
+        metrics = self.parser.parse(output, [], 0)
+        self.assertDictEqual(expected_dict, metrics)
+        metrics = self.parser.parse([], output, 0)
+        self.assertDictEqual(expected_dict, metrics)
+
+    def test_parse_empty_output(self):
+        output = ['']
+        with self.assertRaises(ValueError):
+            self.parser.parse(output, ['garbage'], 1)
+        with self.assertRaises(ValueError):
+            self.parser.parse(['garbage'], output, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds simple JSON parser, useful for whenever a job returns json in its output. Unit tests included.

Basically it just a `json.loads()` on the output, so It will skip blank lines preceding the json data, but if encounters anything, it will try to parse it as JSON and could possibly raise a ValueError. 


