### PR TITLE
[benchpress] Make JSON parser more robust to non-JSON input

### DIFF
--- a/benchpress/benchpress/plugins/parsers/generic.py
+++ b/benchpress/benchpress/plugins/parsers/generic.py
@@ -8,16 +8,22 @@
 
 import json
 import logging
+import re
 
 from benchpress.lib.parser import Parser
+
+JSON_LIKE_REGEX = r'\s*([{\[].*?[}\]]\s*[}\]]*)\s*'
+JSON_LIKE_MATCHER = re.compile(JSON_LIKE_REGEX)
 
 
 class JSONParser(Parser):
     def parse(self, stdout, stderr, returncode):
         """Converts JSON output from either stdout or stderr into a dict.
 
-        Assumes that either stdout or stderr contains only valid JSON, as
-        expected by the `json` module.
+        Assumes that either stdout or stderr contains a section of valid JSON,
+        as expected by the `json` module. Returns only first match of JSON. It
+        will try to scan for JSON-like string sections, REGEX is too simple
+        could miss some contrived cases.
 
         Args:
             stdout (list[str]): Process's line-by-line stdout output.
@@ -32,11 +38,15 @@ class JSONParser(Parser):
         """
         err_msg = 'Failed to parse {1} as JSON: {0}'
         for (output, kind) in [(stdout, 'stdout'), (stderr, 'stderr')]:
-            process_output = '\n'.join(output)
-            try:
-                return json.loads(process_output)
-            except ValueError as err:
-                logging.warning(err_msg.format(err, kind))
+            process_output = ' '.join(output)
+            possible_json_matches = JSON_LIKE_MATCHER.findall(process_output)
+            for m in possible_json_matches:
+                try:
+                    return json.loads(m)
+                except ValueError:
+                    pass
+            else:
+                logging.warning(err_msg.format(ValueError(), kind))
 
         msg = "Couldn't not find or parse JSON from either stdout or stderr"
         raise ValueError(msg)

--- a/benchpress/tests/test_json_parser.py
+++ b/benchpress/tests/test_json_parser.py
@@ -86,6 +86,19 @@ class TestJSONParser(unittest.TestCase):
         metrics = self.parser.parse(['garbage'], output, 0)
         self.assertDictEqual({'hello': 'world', 'x': 42}, metrics)
 
+    def test_two_or_more_valid_json_snippets(self):
+        output = [
+            '',
+            '{"hello": "world", "x": 42}',
+            'some other unreachable garbage',
+            '{ "another valid": "json", "but": "should not be returned" }',
+            '[ "another", "valid", "section" ]'
+        ]
+        metrics = self.parser.parse(output, ['garbage'], 0)
+        self.assertDictEqual({'hello': 'world', 'x': 42}, metrics)
+        metrics = self.parser.parse(['garbage'], output, 0)
+        self.assertDictEqual({'hello': 'world', 'x': 42}, metrics)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/benchpress/tests/test_json_parser.py
+++ b/benchpress/tests/test_json_parser.py
@@ -71,6 +71,21 @@ class TestJSONParser(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.parser.parse(['garbage'], output, 1)
 
+    def test_parse_with_surrounding_garbage(self):
+        output = [
+            '',
+            '{ json-like looking part } }'
+            'some garbage here',
+            '{"hello": "world", "x": 42}',
+            'some other unreachable garbage',
+            '{ some other json like thing }',
+            '[ another ]'
+        ]
+        metrics = self.parser.parse(output, ['garbage'], 0)
+        self.assertDictEqual({'hello': 'world', 'x': 42}, metrics)
+        metrics = self.parser.parse(['garbage'], output, 0)
+        self.assertDictEqual({'hello': 'world', 'x': 42}, metrics)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR tries to make the JSON parser slightly more robust by skipping on input that doesn't look like JSON, and trying out  section of the input that look like JSON. Most likely it will miss some contrived case of JSON mixed with other strings, but it should definitely still pick up JSON-only input.

Context: 
Sometimes programs might output text before and/or after a section of JSON text. Without this PR, it was breaking for those cases.