### PR TITLE
Benchpress/graph500

### DIFF
--- a/benchpress/benchmarks.yml
+++ b/benchpress/benchmarks.yml
@@ -26,3 +26,9 @@ silo:
     - latency:
         - avg_latency
 
+graph500_omp_csr:
+  parser: graph500
+  path: ./benchmarks/graph500/omp-csr
+  metrics:
+    - harmonic_mean_TEPS
+    - harmonic_stddev_TEPS

--- a/benchpress/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/benchpress/plugins/parsers/__init__.py
@@ -8,6 +8,7 @@
 
 from .fio import FioParser
 from .generic import JSONParser
+from .graph500 import Graph500Parser
 from .ltp import LtpParser
 from .returncode import ReturncodeParser
 from .schbench import SchbenchParser
@@ -16,6 +17,7 @@ from .silo import SiloParser
 
 def register_parsers(factory):
     factory.register('fio', FioParser)
+    factory.register('graph500', Graph500Parser)
     factory.register('json', JSONParser)
     factory.register('ltp', LtpParser)
     factory.register('returncode', ReturncodeParser)

--- a/benchpress/benchpress/plugins/parsers/graph500.py
+++ b/benchpress/benchpress/plugins/parsers/graph500.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+import re
+
+from benchpress.lib.parser import Parser
+
+TEPS_REGEX = r'(\w+_TEPS):\s+(\d+\.?\d*e?[+-]\d*)'
+
+
+class Graph500Parser(Parser):
+
+    def parse(self, stdout, stderr, returncode):
+        output = ' '.join(stdout)
+        metrics = {}
+        times = re.findall(TEPS_REGEX, output)
+        for t in times:
+            metrics[t[0]] = float(t[1])
+        return metrics

--- a/benchpress/install_graph500.sh
+++ b/benchpress/install_graph500.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+GRAPH500_GIT_REPO_URL="https://github.com/graph500/graph500.git"
+GRAPH500_GIT_COMMIT_TAG="graph500-2.1.4"
+
+BENCHMARKS_DIR="$(pwd)/benchmarks"
+mkdir -p "$BENCHMARKS_DIR"
+
+GRAPH500_INSTALLATION_PREFIX="${BENCHMARKS_DIR}/graph500"
+GRAPH500_BINARY_PATH="${GRAPH500_INSTALLATION_PREFIX}/omp-csr"
+
+rm -rf build
+mkdir -p build
+cd build/
+
+git clone "$GRAPH500_GIT_REPO_URL"
+cd graph500/
+git checkout -b benchpress tags/"$GRAPH500_GIT_COMMIT_TAG"
+cat <<EOF > make.inc
+BUILD_OPENMP=Yes
+BUILD_MPI=No
+CFLAGS=-O2 -std=c99 -lm
+EOF
+
+
+make omp-csr/omp-csr
+mkdir -p "${GRAPH500_INSTALLATION_PREFIX}"
+mv omp-csr/omp-csr "${GRAPH500_BINARY_PATH}"
+cd ../../
+
+rm -rf build/
+
+echo "Graph500 installed into ${GRAPH500_INSTALLATION_PREFIX}"

--- a/benchpress/jobs/jobs.yml
+++ b/benchpress/jobs/jobs.yml
@@ -1,5 +1,5 @@
 - benchmark: schbench
-  name: schbench default 
+  name: schbench default
   description: defaults for schbench
   args:
     message-threads: 2
@@ -72,3 +72,8 @@
     scale-factor: 1
     runtime: 1
 
+- benchmark: graph500_omp_csr
+  name: graph500_omp_csr
+  description: Graph500 OpenMP Compressed-Sparse-Row
+  args:
+    - -s 20

--- a/benchpress/tests/test_graph500_parser.py
+++ b/benchpress/tests/test_graph500_parser.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import unittest
+
+from benchpress.plugins.parsers.graph500 import Graph500Parser
+
+
+class TestGraph500Parser(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = Graph500Parser()
+
+    def test_graph500_output(self):
+        output = [
+            'SCALE: 20',
+            'nvtx: 1048576',
+            'edgefactor: 16',
+            'terasize: 2.68435455999999995e-04',
+            'A: 5.69999999999999951e-01',
+            'B: 1.90000000000000002e-01',
+            'C: 1.90000000000000002e-01',
+            'D: 5.00000000000000444e-02',
+            'generation_time: 7.66684459000000018e+00',
+            'construction_time: 6.41681591700000009e+00',
+            'nbfs: 64',
+            'min_time: 2.15880087000000026e-01',
+            'firstquartile_time: 2.67573745249999995e-01',
+            'median_time: 2.89870043500000008e-01',
+            'thirdquartile_time: 3.04702949249999966e-01',
+            'max_time: 5.52760817999999987e-01',
+            'mean_time: 2.96250436796875016e-01',
+            'stddev_time: 5.09852699808539048e-02',
+            'min_nedge: 1.67770270000000000e+07',
+            'firstquartile_nedge: 1.67770270000000000e+07',
+            'median_nedge: 1.67770270000000000e+07',
+            'thirdquartile_nedge: 1.67770270000000000e+07',
+            'max_nedge: 1.67770270000000000e+07',
+            'mean_nedge: 1.67770270000000000e+07',
+            'stddev_nedge: 0.00000000000000000e+00',
+            'min_TEPS: 3.03513318123789318e+07',
+            'firstquartile_TEPS: 5.58372454800551683e+07',
+            'median_TEPS: 5.84075242403832078e+07',
+            'thirdquartile_TEPS: 6.31682987237617970e+07',
+            'max_TEPS: 7.77145647527925968e+07',
+            'harmonic_mean_TEPS: 5.66312312697220370e+07',
+            'harmonic_stddev_TEPS: 1.22792390265783062e+06',
+        ]
+        metrics = self.parser.parse(output, None, 0)
+        self.assertDictEqual({
+                'min_TEPS': float('3.03513318123789318e+07'),
+                'firstquartile_TEPS': float('5.58372454800551683e+07'),
+                'median_TEPS': float('5.84075242403832078e+07'),
+                'thirdquartile_TEPS': float('6.31682987237617970e+07'),
+                'max_TEPS': float('7.77145647527925968e+07'),
+                'harmonic_mean_TEPS': float('5.66312312697220370e+07'),
+                'harmonic_stddev_TEPS': float('1.22792390265783062e+06'),
+            }, metrics)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds Graph500 v2.1.4 OpenMP CSR benchmark

Example of actual run through Benchpress:
```
$ OMP_NUM_THREADS=1 python3.6 ./benchpress_cli.py -b benchmarks.yml -j jobs/jobs.yml run graph500_omp_csr
Will run 1 job(s)
Running "graph500_omp_csr": Graph500 OpenMP Compressed-Sparse-Row
{
  "firstquartile_TEPS": 63331410.29358231,
  "harmonic_mean_TEPS": 64832533.056823656,
  "harmonic_stddev_TEPS": 667812.4890618721,
  "max_TEPS": 85892410.57274126,
  "median_TEPS": 64781042.87450379,
  "min_TEPS": 49649920.68025839,
  "thirdquartile_TEPS": 66771695.51119673
}
```