### PR TITLE
netcons: Reassemble LOG_CONT messages properly, kill cont_start

### DIFF
--- a/ncrx/ncrx-struct.h
+++ b/ncrx/ncrx-struct.h
@@ -41,10 +41,10 @@ struct ncrx_msg {
 
 	uint8_t			facility;	/* log facility */
 	uint8_t			level;		/* printk level */
-	unsigned		cont_start:1;	/* first of continued msgs */
 	unsigned		cont:1;		/* continuation of prev msg */
 	unsigned		oos:1;		/* sequence out-of-order */
 	unsigned		seq_reset:1;	/* sequence reset */
+	unsigned		cont_merged:1;	/* blanked continuation of prev msg to preserve sequence */
 
 	/* private fields */
 	struct ncrx_list	node;

--- a/ncrx/ncrx.c
+++ b/ncrx/ncrx.c
@@ -143,8 +143,7 @@ int main(int argc, char **argv)
 
 			printf("%s", msg->text);
 
-			prev_cont = msg->cont_start || msg->cont;
-			if (!prev_cont)
+			if (!msg->cont)
 				printf("\n");
 		}
 

--- a/ncrx/ncrx.h
+++ b/ncrx/ncrx.h
@@ -46,6 +46,11 @@
  *	A missing message expires after this period and the sequence number
  *	will be skipped in the output.
  *
+ * cont_msg_timeout
+ *	If cont_merging_enabled is true, when waiting for completion of a CONT
+ *	sequence, we will finalise reassembly of the CONT message without a clear
+ *	ending message after this period.
+ *
  * oos_thr
  *	Among last 32 message, if more than this number of messages are
  *	out-of-order, the message stream is reset.
@@ -57,6 +62,11 @@
  * oos_timeout
  *	If sequence is not reset in this period after reception of an
  *	out-of-order message, the message is output.
+ *
+ * cont_merging_enabled
+ *  Enable merging subsequent text of CONT sequences into the first packet.
+ *  This will introduce an extra delay of cont_msg_timeout extra ms to allow
+ *  time to receive further CONT packets.
  */
 struct ncrx_param {
 	int			nr_slots;
@@ -65,10 +75,13 @@ struct ncrx_param {
 	int			retx_intv;
 	int			retx_stride;
 	int			msg_timeout;
+	int			cont_msg_timeout;
 
 	int			oos_thr;
 	int			oos_intv;
 	int			oos_timeout;
+
+	int			cont_merging_enabled;
 };
 
 /* default params */
@@ -79,10 +92,13 @@ struct ncrx_param {
 #define NCRX_DFL_RETX_INTV	1000
 #define NCRX_DFL_RETX_STRIDE	256
 #define NCRX_DFL_MSG_TIMEOUT	30000
+#define NCRX_DFL_CONT_MSG_TIMEOUT	10000
 
 #define NCRX_DFL_OOS_THR	(32 * 3 / 5)			/* 19 */
 #define NCRX_DFL_OOS_INTV	5000
 #define NCRX_DFL_OOS_TIMEOUT	NCRX_DFL_MSG_TIMEOUT
+
+#define NCRX_DFL_CONT_MERGING_ENABLED	1
 
 /*
  * A ncrx instance is created by ncrx_create() and destroyed by

--- a/netconsd/modules/logger.cc
+++ b/netconsd/modules/logger.cc
@@ -120,7 +120,6 @@ static void write_log(struct logtarget& tgt, struct msgbuf *buf,
 	else
 		dprintf(tgt.fd, "%06lu %014lu %d %d %s%s%s%s%s\n", msg->seq,
 			msg->ts_usec, msg->facility, msg->level,
-			msg->cont_start ? "[CONT START] " : "",
 			msg->cont ? "[CONT] " : "",
 			msg->oos ? "[OOS] ": "",
 			msg->seq_reset ? "[SEQ RESET] " : "",

--- a/netconsd/modules/printer.c
+++ b/netconsd/modules/printer.c
@@ -40,7 +40,6 @@ void netconsd_output_handler(int t, struct in6_addr *src, struct msgbuf *buf,
 	else
 		printf("%40s: S%06lu T%014lu F%d/L%d %s%s%s%s%s\n", addr,
 			msg->seq, msg->ts_usec, msg->facility, msg->level,
-			msg->cont_start ? "[CONT START] " : "",
 			msg->cont ? "[CONT] " : "",
 			msg->oos ? "[OOS] ": "",
 			msg->seq_reset ? "[SEQ RESET] " : "",


### PR DESCRIPTION
The kernel has a concept of "continuable" messages, as implemented by
the LOG_CONT flag. Previously netcons hasn't had the logic to assemble
these messages, which resulted in missing context for things like
register and state information when getting CPU backtraces, and a whole
host of other lost pieces of context.

This code handles this by introducing a timeout waiting for the
appearance of followup CONT messages (`NCRX_DFL_CONT_MSG_TIMEOUT`,
currently 10000ms) in order to reassemble them to be included into the
current netcons message. We do not include the metadata from these
LOG_CONT messages, we only attempt to merge the textual content included
in the netcons packet. Further sequence numbers are returned with their
text and dict memset to 0 in order to still have the ability to detect
holes in the sequence numbers received.

Here are some questions you may have after reading this patch:

- *Why isn't checking for cont_start enough?* cont_start has also been
  killed as it didn't work properly -- as it was, all LOG_CONT packets
  were improperly being flagged as cont_start, when they should have
  been marked as LOG_CONT. As it is, the kernel doesn't currently have
  any way of flagging these packets.
- *Why do we need `NCRX_DFL_CONT_MSG_TIMEOUT`?* Unfortunately, with the
  current netcons implementation in printk.c, it's actually not possible
  to know which packets will initiate a continuation sequence, which is
  why we wait NCRX_DFL_CONT_MSG_TIMEOUT milliseconds before abandoning
  attempted reassembly.
- *Can't we just fix the kernel?* Yes, and while we can do that, this
  isn't going to fix things for older kernels without changes to
  printk.c, so we still need to be able to handle them.
- *How can a caller know which packets are missing?* The same way we do
  normal sequence skip checking, since other messages are returned as
  husks with their content memset to 0. It is nice (but not required) to
  then skip messages with LOG_CONT set and have `strlen(msg->text) ==
  0` on the caller side.

Test Plan:

1. Set one machine up to forward netcons messages to another using
   bootparams
2. Run ncrx on the other and see `LOG_CONT` messages (in this case from
   `l` to sysrq-trigger) are reassembled before retrieval:

    [18844.440547] RAX: ffffffffffffffda RBX: 0000000000000002 RCX: 00007f5d45db1e7d
    [18844.440548] RDX: 0000000000000000 RSI: 0000000000000000 RDI: 0000000000000004
    [18844.440548] RBP: 0000000000000004 R08: 0000000000000000 R09: 0000000000000050
    [18844.440548] R10: 0000000000000001 R11: 0000000000000293 R12: 00007ffd50c3cdc0
    [18844.440549] R13: 00007ffd50c3d130 R14: 0000000000000000 R15: 0000000000000000
    [18844.440549] Code: 00 00 55 [...]