### PR TITLE
README: Updating port parameter

### DIFF
--- a/netconsd/README
+++ b/netconsd/README
@@ -48,7 +48,7 @@ Setting up the server
 ---------------------
 
 By default, netconsd will use 1 listener and 2 worker threads, and listen on
-port 1514 for messages. You can use "-l", "-w", and "-p" respectively to change
+port 1514 for messages. You can use "-l", "-w", and "-u" respectively to change
 the defaults.
 
 There's no universal wisdom about how many threads to use: just experiment with


### PR DESCRIPTION
-p doesn't exist anymore, -u should be used instead.

Signed-off-by: Erwan Velu <e.velu@criteo.com>