### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/netconsd/website/siteConfig.js
+++ b/netconsd/website/siteConfig.js
@@ -69,6 +69,11 @@ const siteConfig = {
   ogImage: 'img/bpf_logo.png',
   twitterImage: 'img/bpf_logo.png',
 
+  algolia: {
+    apiKey: 'd72e780917c72c5a9fa325cdf2d7ed01',
+    indexName: 'fbkutils', 
+  },
+
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
   repoUrl: 'https://github.com/facebook/fbkutils/tree/master/netconsd',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.