### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/netconsd/website/siteConfig.js
+++ b/netconsd/website/siteConfig.js
@@ -10,6 +10,10 @@ const users = [
 ];
 
 const siteConfig = {
+  algolia: {
+    apiKey: '5d3ec58089ecfafc5b888c1aca10cee7',
+    indexName: 'netconsd'
+  },
   title: 'netconsd' /* title for your website */,
   tagline: 'Extending the Linux netconsole',
   url: 'https://facebook.github.io' /* your website url */,


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.